### PR TITLE
環境起動するためのinit.sqlファイル

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 DB_HOST=db
 DB_USER=testuser
 DB_PASSWORD=testuser
-DB_DATABASE=chatapp
+DB_DATABASE=woprchatapp
 # MySQL root password
 DB_ROOT_PASSWORD=root
 

--- a/Docker/MySQL/init.sql
+++ b/Docker/MySQL/init.sql
@@ -1,0 +1,33 @@
+
+DROP DATABASE woprchatapp;
+DROP USER 'testuser';
+
+CREATE USER 'testuser' IDENTIFIED BY 'testuser';
+CREATE DATABASE woprchatapp;
+USE woprchatapp
+GRANT ALL PRIVILEGES ON woprchatapp.* TO 'testuser';
+
+CREATE TABLE users (
+    uid VARCHAR(255) PRIMARY KEY,
+    user_name VARCHAR(255) UNIQUE NOT NULL,
+    email VARCHAR(255) UNIQUE NOT NULL,
+    password VARCHAR(255) NOT NULL
+);
+
+CREATE TABLE channels (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    uid VARCHAR(255) NOT NULL,
+    name VARCHAR(255) UNIQUE NOT NULL,
+    abstract VARCHAR(255),
+    FOREIGN KEY (uid) REFERENCES users(uid) ON DELETE CASCADE
+);
+
+CREATE TABLE messages (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    uid VARCHAR(255) NOT NULL,
+    cid INT NOT NULL,
+    message TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (uid) REFERENCES users(uid) ON DELETE CASCADE,
+    FOREIGN KEY (cid) REFERENCES channels(id) ON DELETE CASCADE
+);


### PR DESCRIPTION
.env.example：B_DATABASEの名前を変更

環境起動するために「init.sql」が必要な為、仮で作成したファイルを追加
Docker
　-MySQL
　　-init.sql